### PR TITLE
removed links to fall 2023 biotips files

### DIFF
--- a/templates/resources_template.md
+++ b/templates/resources_template.md
@@ -16,7 +16,9 @@ The FAS Informatics Group creates resources for bioinformatics analysis in the f
 
 ## Current workshops
 
-### Introduction to R
+Below is a list of all current workshops the Informatics Group runs. Workshop files may be temporarily unavailable as we update them during ongoing sessions.
+
+### Introduction to R (Fall 2023)
 
 This workshop aims to introduce first-time users to the [R programming language](https://www.r-project.org/) and the [RStudio](https://posit.co/download/rstudio-desktop/) development environment. We will provide a basic introduction to coding in R and then shift to data manipulation using the [tidyverse](https://www.tidyverse.org/), a set of R libraries designed to handle data tables in a consistent and easy way. Then, we'll learn how to generate some basic plots to explore our data using [ggplot](https://ggplot2.tidyverse.org/). You do not need any prior programming experience to take this workshop. But also note that this workshop is not a comprehensive programming class nor a comprehensive statistics class. The main goal of this workshop is to get you familiar with reading your data into R and performing basic operations and generating figures.
 
@@ -26,16 +28,16 @@ This workshop aims to introduce first-time users to the [R programming language]
 - [Part 2: Introduction to data manipulation with the tidyverse](Workshops/R/R-workshop-2023-Part2.md) - [Download student RMD file](Workshops/R/R-workshop-2023-Part2-student.Rmd)
 - [Part 3: Introduction to data visualization with ggplot](Workshops/R/R-workshop-2023-Part3.md) - [Download student RMD file](Workshops/R/R-workshop-2023-Part3-student.Rmd)
 
-### Unix tips and tricks for bioinformatics
+### Unix tips and tricks for bioinformatics (currently updating for Spring 2024)
 
 This workshop aims to introduce students to some basic bioinformatics file formats, tools, and general best practices. The first two days of the workshop will be dedicated to introductions of bioinformatics file formats and the command line tools that we use to view, manipulate, and analyze them. After that, we will begin to shift from using individual commands to writing shell scripts and constructing bioinformatics workflows.
 
-- [Workshop information](Workshops/Unix/index.html)
-- [Get started](Workshops/Unix/start.html)
-- [Part 1: Bioinformatics tools and file formats 1: FASTA, FASTQ, grep, BAM/SAM, samtools](Workshops/Unix/Biotips-workshop-2023-Day1.md) - [Download student RMD file](Workshops/Unix/Biotips-workshop-2023-Day1-student.Rmd)
-- [Part 2: Bioinformatics tools and file formats 2: bed, awk, bedtools](Workshops/Unix/Biotips-workshop-2023-Day2.md) - [Download student RMD file](Workshops/Unix/Biotips-workshop-2023-Day2-student.Rmd)
-- [Part 3: Bioinformatics tools and file formats 3: GFF, VCF, bcftools](Workshops/Unix/Biotips-workshop-2023-Day3.md) - [Download student RMD file](Workshops/Unix/Biotips-workshop-2023-Day3-student.Rmd)
-- [Part 4: Shell scripting](Workshops/Unix/Biotips-workshop-2023-Day4.md) - [Download student RMD file](Workshops/Unix/Biotips-workshop-2023-Day4-student.Rmd)
+- [Workshop information](https://harvardinformatics.github.io/workshops/2024-spring/biotips/)
+- [Get started](https://harvardinformatics.github.io/workshops/2024-spring/biotips/start.html)
+<!-- - [Part 1: Bioinformatics tools and file formats 1: FASTA, FASTQ, grep, BAM/SAM, samtools](Workshops/Unix/Biotips-workshop-2023-Day1.md) - [Download student RMD file](Workshops/Unix/Biotips-workshop-2023-Day1-student.Rmd) -->
+<!-- - [Part 2: Bioinformatics tools and file formats 2: bed, awk, bedtools](Workshops/Unix/Biotips-workshop-2023-Day2.md) - [Download student RMD file](Workshops/Unix/Biotips-workshop-2023-Day2-student.Rmd) -->
+<!-- - [Part 3: Bioinformatics tools and file formats 3: GFF, VCF, bcftools](Workshops/Unix/Biotips-workshop-2023-Day3.md) - [Download student RMD file](Workshops/Unix/Biotips-workshop-2023-Day3-student.Rmd) -->
+<!-- - [Part 4: Shell scripting](Workshops/Unix/Biotips-workshop-2023-Day4.md) - [Download student RMD file](Workshops/Unix/Biotips-workshop-2023-Day4-student.Rmd) -->
 
 ## External resources
 


### PR DESCRIPTION
since we are currently updating them. resources page now looks like:

![image](https://github.com/harvardinformatics/informatics-website/assets/12522633/26791127-1bcb-4e98-a21b-08be2e746122)
