### PR TITLE
author rows with many authors on mobile no longer stack

### DIFF
--- a/docs/css/author-row.css
+++ b/docs/css/author-row.css
@@ -10,13 +10,6 @@
   padding-bottom: 0.75em;
   /* gap: 0.75em; */
 }
-@media (max-width: 600px) {
-  .author-row {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.25em;
-  }
-}
 
 .page-maintainer-row {
   border: none;
@@ -40,3 +33,47 @@
   border-radius:50%; 
   object-fit: cover;
 }
+
+.author-row-last-updated {
+  margin: 0 0.4em;
+}
+
+@media (max-width: 600px) {
+  .author-row.many-authors {
+    flex-direction: row !important;
+    flex-wrap: wrap;
+    gap: 0.3em;
+  }
+  .author-row.many-authors .author-header {
+    display: block;
+    width: 100%;
+    margin-bottom: 0.4em;
+    margin-right: 0;  /* Undo inline margin */
+  }
+
+  /* .author-row.many-authors a img {
+    width: 24px;
+    height: 24px;
+  } */
+  .author-row.few-authors {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25em;
+  }
+  /* .author-row.few-authors a img {
+    width: 32px;
+    height: 32px;
+  } */
+
+  .author-row-last-updated {
+    display: block;
+    width: 100%;
+    /* margin-top: 0.5em; */
+    margin-left: 0;    /* ensures no indent from previous line */
+    margin-right: 0;
+  }
+
+  .author-row-dot {
+    display: none; /* Hide the dot in mobile view */
+  }
+} 

--- a/scripts/macros.py
+++ b/scripts/macros.py
@@ -50,12 +50,19 @@ def define_env(env):
         authors = page.meta.get('authors') or [page.meta.get('author')]
         author_header = page.meta.get('author_header', 'Authors')
 
-        if author_header == "Authors" and len(authors) == 1:
+        many_authors_threshold = 4;
+        num_authors = len(authors)
+        many_authors = False
+        if num_authors >= many_authors_threshold:
+            many_authors = True
+
+        if author_header == "Authors" and num_authors == 1:
             # If there's only one author, change the header to "Author"
             author_header = "Author"
 
         # Start building the HTML output
-        line = '<span class="author-row">'
+        author_class = "author-row many-authors" if many_authors else "author-row few-authors"
+        line = f'<span class="{author_class}">'
         if author_header == "Page maintainer":
             # If this is a maintainer entry, use a different header
             line = '<span class="author-row page-maintainer-row">'
@@ -78,7 +85,8 @@ def define_env(env):
         # Finish the HTML with last updated info if not for a maintainer entry
         if author_header != "Page maintainer":
             line += '''
-<span style="margin: 0 0.4em;">·
+<span class="author-row-last-updated">
+<span class="author-row-dot">·</span>
 <small style="color: #888;">
     :material-clock-edit-outline: Last updated: {{ git_revision_date_localized }}
 </small>


### PR DESCRIPTION
On mobile screens <600px wide, the author rows with many authors that only show the author's images would stack. Now they stay on one row.