### PR TITLE
fixed the text of profile headers on mobile so they stack with the img

### DIFF
--- a/docs/css/profile-header.css
+++ b/docs/css/profile-header.css
@@ -32,3 +32,20 @@
   font-size: 0.45em; 
   color: #666;
 }
+
+@media (max-width: 600px) {
+  .profile-header {
+    flex-direction: column;
+    align-items: center; /* Optional: center image/text horizontally */
+    gap: 0.7em;          /* Optional: smaller gap for mobile */
+  }
+  .profile-header img {
+    margin-right: 0;     /* Remove right margin, so it's centered above text */
+    width: 60vw;         /* Optionally, use a more natural mobile width (max stays 200px) */
+    max-width: 200px;
+  }
+  .profile-name {
+    align-items: center; /* Center name/title/office under the image */
+    text-align: center;
+  }
+}


### PR DESCRIPTION
Even though it looked ok on a desktop mobile test environment, on actual mobile browsers the text in profile headers overflowed off the viewport when next to the profile image. This moves the profile header text below the profile image on mobile.