### PR TITLE
rm profile header brs since they increase spacing on mobile

### DIFF
--- a/templates/profile_template.md
+++ b/templates/profile_template.md
@@ -8,8 +8,8 @@ hide:
 <h1 class="profile-header">
   <img src="../../img/people/{person_lower}.jpg" alt="{person}">
   <span class="profile-name">
-    {person}<br>
-    <span class="profile-title">{person_title}</span><br>
+    {person}
+    <span class="profile-title">{person_title}</span>
     <span class="profile-office">Northwest Labs {person_office}</span>
   </span>
 </h1>


### PR DESCRIPTION
The previous fix to the profile headers on mobile looked fine on the desktop tests, but on actual mobile there was a big space between the person's title and office. I'm removing the <br> tags to try and fix this, but since this only shows up on actual mobile browsers this is really annoying to have to do 1 change at a time, pr, build and check.